### PR TITLE
Configure Dependabot for npm with daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+  updates:
+    - package-ecosystem: npm
+      directory: "/"
+      schedule:
+        interval: daily
+        time: "11:00"
+        timezone: America/Chicago
+      groups:
+        npm-all:
+          patterns:
+            - "*"
+


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/issues/9771
Updated Dependabot configuration to use npm and set daily updates.